### PR TITLE
Small readability improvement

### DIFF
--- a/src/nano_id/core.cljc
+++ b/src/nano_id/core.cljc
@@ -11,13 +11,6 @@
   Generates IDs of the specified `size`, it's 21 by default."
   ([] (nano-id 21))
   ([size]
-   (loop [mask  0x3f
-          bytes (rnd/random-bytes size)
-          id    #?(:clj (StringBuilder.) :cljs "")]
-     (if bytes
-       (recur mask
-              (next bytes)
-              (let [ch (nth alphabet (bit-and (first bytes) mask))]
-                #?(:clj (.append id ch) :cljs (str id ch))))
-       (str id)))))
-
+   (->> (rnd/random-bytes size)
+        (map #(nth alphabet (bit-and % 0x3f)))
+        (apply str))))


### PR DESCRIPTION
Looking at definition of [str at clojure.core](https://github.com/clojure/clojure/blob/master/src/clj/clojure/core.clj#L554), I think this version of `core/nano-id` implementation is totally equivalent, but a little bit more readable and easier to maintain. But it's just my opinion, no pushing :) 