### PR TITLE
Fix ReferenceError: “crypto” undefined, in IE11

### DIFF
--- a/src/nano_id/random.cljc
+++ b/src/nano_id/random.cljc
@@ -6,7 +6,10 @@
 
 (def ^:private secure-random
   #?(:clj  NanoID/secureRandom
-     :cljs js/crypto))
+     :cljs (try
+             js/crypto
+             (catch :default _
+               js/msCrypto))))
 
 
 (defn random-bytes


### PR DESCRIPTION
Following advice documented on MDN:
https://developer.mozilla.org/en-US/docs/Web/API/Window/crypto

Maybe not the most elegant way to solve this. So feel free to edit, or ask me to do it.
This is how I made it work for my app.